### PR TITLE
Added ADC Pin Labels

### DIFF
--- a/Pimoroni_PGA2350/pimoroni_pga2350.kicad_sym
+++ b/Pimoroni_PGA2350/pimoroni_pga2350.kicad_sym
@@ -926,7 +926,7 @@
 			(pin bidirectional line
 				(at 35.56 1.27 180)
 				(length 3.81)
-				(name "GPIO40"
+				(name "GPIO40_ADC0"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -951,7 +951,7 @@
 			(pin bidirectional line
 				(at 35.56 3.81 180)
 				(length 3.81)
-				(name "GPIO41"
+				(name "GPIO41_ADC1"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -976,7 +976,7 @@
 			(pin bidirectional line
 				(at 35.56 6.35 180)
 				(length 3.81)
-				(name "GPIO42"
+				(name "GPIO42_ADC2"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -1001,7 +1001,7 @@
 			(pin bidirectional line
 				(at 35.56 8.89 180)
 				(length 3.81)
-				(name "GPIO43"
+				(name "GPIO43_ADC3"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -1026,7 +1026,7 @@
 			(pin bidirectional line
 				(at 35.56 11.43 180)
 				(length 3.81)
-				(name "GPIO44"
+				(name "GPIO44_ADC4"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -1051,7 +1051,7 @@
 			(pin bidirectional line
 				(at 35.56 13.97 180)
 				(length 3.81)
-				(name "GPIO45"
+				(name "GPIO45_ADC5"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -1076,7 +1076,7 @@
 			(pin bidirectional line
 				(at 35.56 16.51 180)
 				(length 3.81)
-				(name "GPIO46"
+				(name "GPIO46_ADC6"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -1101,7 +1101,7 @@
 			(pin bidirectional line
 				(at 35.56 19.05 180)
 				(length 3.81)
-				(name "GPIO47"
+				(name "GPIO47_ADC7"
 					(effects
 						(font
 							(size 1.27 1.27)


### PR DESCRIPTION
Pretty simple update if you're open to contributions! Just changed the symbol to note which of the GPIO pins are also ADC pins! 

Updated symbol: 
<img width="682" alt="Screenshot 2025-01-15 at 3 02 47 PM" src="https://github.com/user-attachments/assets/3828a414-8237-427d-b113-90dc4ea5cc1d" />
